### PR TITLE
Always set data descriptor bit flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,13 +71,8 @@ impl FileHeader {
         }
         handle.write_all(&10u16.to_le_bytes())?; // Version needed to extract (minimum) => 1.0
         written += 2;
-        if self.data_descriptor.is_some() {
-            handle.write_all(&0b0000_0000u16.to_le_bytes())?; // General purpose bit flag
-            written += 2;
-        } else {
-            handle.write_all(&0b0000_1000u16.to_le_bytes())?; // General purpose bit flag => enable data descriptors
-            written += 2;
-        }
+        handle.write_all(&0b0000_1000u16.to_le_bytes())?; // General purpose bit flag => enable data descriptor
+        written += 2;
         let compression_num: u16 = match self.compression {
             CompressionMode::Store => 0,
             CompressionMode::Deflate(_) => 8,


### PR DESCRIPTION
7zip refuses to extract zip archives if the general purpose bit flags
set in the local file header and central directory file header are not
equal. To resolve this, the data descriptor bit flag is set regardless
of whether or not `self.data_descriptor` is `None` in the `write` method
for `FileHeader`.

This does not strictly adhere to the ZIP standard, but setting the data
descriptor bit flag in the central directory file header as well as in
the local file header did not make the archive unreadable in my testing.
(I tried extracting the resulting archive with p7zip and unzip on linux)